### PR TITLE
Fix typos in rebar.config.

### DIFF
--- a/riak_core.rebar.config
+++ b/riak_core.rebar.config
@@ -1,6 +1,6 @@
 {sub_dirs, ["rel", "apps/{{appid}}"]}.
-{cover_enabled, true.}
+{cover_enabled, true}.
 {erl_opts, [debug_info, fail_on_warning]}.
-{deps, [{riak_core, "0.14..*",
+{deps, [{riak_core, "0.14.*",
          {git, "git://github.com/basho/riak_core", "master"}}
        ]}.


### PR DESCRIPTION
Fixed a few typos, one of which caused a parse error.
